### PR TITLE
Feature/change apt get source server

### DIFF
--- a/backend/Dockerfile.local
+++ b/backend/Dockerfile.local
@@ -1,5 +1,9 @@
 FROM ubuntu:22.04
 
+# change apt source
+RUN sed -i 's/archive.ubuntu.com/mirror.kakao.com/g' /etc/apt/sources.list
+RUN sed -i 's/security.ubuntu.com/mirror.kakao.com/g' /etc/apt/sources.list
+
 # Install basic
 RUN apt-get update -y && \
     apt-get install -y \


### PR DESCRIPTION
### 설명

<!-- PR이 해결하고자 하는 문제를 설명합니다. -->
#14 issue를 해결하는 PR입니다.

### 테스트 방법

<!-- 리뷰어가 테스트해볼 수 있는 방법을 설명합니다. -->
하기 명령어로 build를 해 보면, build 시간이 단축됨을 알 수 있습니다.
`docker-compose -f docker-compose.local.yml build --no-cache`

### 체크리스트

- [x] 스타일 가이드를 따르고 있습니다.
- [x] 스스로 코드를 검토하고 오타를 수정하였습니다.
- [x] 이해하기 어려운 부분이 있는지 확인하고 필요한 경우 주석을 추가했습니다.
- [x] 콘솔에서 경고(warnings)가 발생하지 않습니다.


`/backend/Dockerfile.local`에 

```
# change apt-get source
RUN sed -i 's/archive.ubuntu.com/mirror.kakao.com/g' /etc/apt/sources.list
RUN sed -i 's/security.ubuntu.com/mirror.kakao.com/g' /etc/apt/sources.list
```
를 추가했습니다.
dockerfile을 build할 때 apt-get source에서 package를 가져오는 부분에서 병목현상이 심하게 일어나서, 그냥 한국에서 가장 빠른 `mirror.kakao.com` server로 변경했습니다.

이렇게 바꾸니 local build 시 400초대에서 100초대로 단축됐습니다. (제 local 환경 기준입니다.)
