### PR TITLE
chore(fe): add .gitignore in project root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+backend/.old_java_code
+backend/app/__pycache__


### PR DESCRIPTION
backend branch에서 작업하다가, frontend branch로 switch 하면 `backend/app/__pycache__` directory 남아 있어서, 이를 해결하기 위해서 project root directory에 .gitignore file을 dev/backend branch에 있는 걸로 하나 그대로 가져왔습니다.

### 설명

<!-- PR이 해결하고자 하는 문제를 설명합니다. -->
#15 issue를 해결하고자 합니다.
### 테스트 방법

<!-- 리뷰어가 테스트해볼 수 있는 방법을 설명합니다. -->

### 체크리스트

- [x] 스타일 가이드를 따르고 있습니다.
- [x] 스스로 코드를 검토하고 오타를 수정하였습니다.
- [x] 이해하기 어려운 부분이 있는지 확인하고 필요한 경우 주석을 추가했습니다.
- [x] 콘솔에서 경고(warnings)가 발생하지 않습니다.