### PR TITLE
fix(be): update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 backend/.old_java_code
 backend/app/__pycache__
+
+# asdf .tool-versions
+.tool-versions


### PR DESCRIPTION
local에서 돌릴 경우를 대비하여 asdf로 local python version을 명시해둔 .tool-versions 파일을 gitignore에 추가했습니다.

### 설명

<!-- PR이 해결하고자 하는 문제를 설명합니다. -->

제가 local에서 asdf를 사용해서 python runtime을 관리하는데, project root에서 `.tool-versions` file을 이용해, 해당 project의 python runtime을 명시하고 결정합니다. 
딴 팀원분들은 각기 다른 runtime version 관리 툴을 사용하기 때문에, `.gitignore`에서 `tool-versions` file을 제외하도록 했습니다.

### 테스트 방법

<!-- 리뷰어가 테스트해볼 수 있는 방법을 설명합니다. -->

### 체크리스트

- [x] 스타일 가이드를 따르고 있습니다.
- [x] 스스로 코드를 검토하고 오타를 수정하였습니다.
- [x] 이해하기 어려운 부분이 있는지 확인하고 필요한 경우 주석을 추가했습니다.
- [x] 콘솔에서 경고(warnings)가 발생하지 않습니다.