### PR TITLE
✨add driving_length and flying info in api return

### DIFF
--- a/backend/app/module/carbon_calc/green_algorithm.py
+++ b/backend/app/module/carbon_calc/green_algorithm.py
@@ -59,7 +59,7 @@ class GreenAlgorithmFields:
     # RUNTIME DATA
     runtime_hours: float  # hours
     runtime_minutes: float  # minutes
-    runtime_seconds: float # seconds
+    runtime_seconds: float  # seconds
     runtime: float = None
 
     def __init__(self, **kwargs) -> None:
@@ -67,7 +67,11 @@ class GreenAlgorithmFields:
         self.__post_init__()  # explictly call __post_init__ because of custom init
 
     def __post_init__(self) -> None:
-        self.runtime = self.runtime_hours + self.runtime_minutes / 60 + self.runtime_seconds / (60*60)
+        self.runtime = (
+            self.runtime_hours
+            + self.runtime_minutes / 60
+            + self.runtime_seconds / (60 * 60)
+        )
 
 
 class GreenAlgorithm:
@@ -98,7 +102,9 @@ class GreenAlgorithm:
             result_dict["power_needed_cpu"] + result_dict["power_needed_gpu"]
         )
         result_dict["power_needed_memory"] = self.ga_data.pue_used * (
-            self.ga_data.memory / (1024*1024) * self.ga_data.constants.ref_values_dict["memoryPower"]
+            self.ga_data.memory
+            / (1024 * 1024)
+            * self.ga_data.constants.ref_values_dict["memoryPower"]
         )
         result_dict["power_needed"] = (
             result_dict["power_needed_core"] + result_dict["power_needed_memory"]
@@ -206,4 +212,9 @@ class GreenAlgorithm:
         return {
             "carbon_emissions": ce["carbon_emissions"],
             "energy_needed": ce["energy_needed"],
+            "tree_month": tm,
+            "driving_length_us": dk["us_nkm"],
+            "driving_length_eu": dk["eu_nkm"],
+            "flying_path": dk["flying_text"],
+            "flying_ratio": dk["flying_context"],
         }


### PR DESCRIPTION
### 설명

기존 /carbon_emission_calculate API 리턴값에
탄소 배출량과 관련된 다음과 같은 변수를 추가하였습니다.
상세한 정보는 노션의 API 문서 참고 바랍니다.

```
driving_length_us
driving_length_eu
flying_path
flying_ratio
```



### 테스트 방법

기존과 동일하며, 잘 작동하는 것을 확인하였습니다.

![image](https://github.com/skkuse/2023fall_41class_team2/assets/37038105/fefdfc25-7f38-4378-abe5-1a2a13f6e14c)


### 체크리스트

- [x] 스타일 가이드를 따르고 있습니다.
- [x] 스스로 코드를 검토하고 오타를 수정하였습니다.
- [x] 이해하기 어려운 부분이 있는지 확인하고 필요한 경우 주석을 추가했습니다.
- [x] 콘솔에서 경고(warnings)가 발생하지 않습니다.